### PR TITLE
update span start_opts to include attributes, sampling hint and start_time

### DIFF
--- a/src/ot_span.erl
+++ b/src/ot_span.erl
@@ -32,9 +32,12 @@
 -include("opentelemetry.hrl").
 
 -type start_opts() :: #{parent => undefined | opentelemetry:span() | opentelemetry:span_ctx(),
+                        attributes => opentelemetry:attributes(),
                         sampler => ot_sampler:sampler(),
+                        sampling_hint => ot_sampler:sampling_decision(),
                         links => opentelemetry:links(),
                         is_recorded => boolean(),
+                        start_time => wts:timestamp(),
                         kind => opentelemetry:span_kind()}.
 
 -export_type([start_opts/0]).


### PR DESCRIPTION
Just adds to the spec some start opts that are required to support.