### PR TITLE
include erlang docs in elixir docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+edoc
 .rebar3
 _*
 .eunit

--- a/mix.exs
+++ b/mix.exs
@@ -18,7 +18,12 @@ defmodule OpenTelemetry.MixProject do
         main: "OpenTelemetry",
         # logo: "path/to/logo.png",
         extras: erlang_docs()
-      ]
+      ],
+      aliases: [
+        # when build docs first build edocs with rebar3
+        docs: ["cmd rebar3 edoc", "docs"]
+      ],
+      package: package()
     ]
   end
 
@@ -37,6 +42,16 @@ defmodule OpenTelemetry.MixProject do
     [
       {:cmark, "~> 0.7", only: :dev, runtime: false},
       {:ex_doc, "~> 0.21", only: :dev, runtime: false}
+    ]
+  end
+
+  defp package() do
+    [
+      description: "OpenTelemetry API",
+      build_tools: ["rebar3", "mix"],
+      licenses: ["Apache-2.0"],
+      links: %{"GitHub" => "https://github.com/open-telemetry/opentelemetry-erlang-api",
+               "OpenTelemetry.io" => "https://opentelemetry.io"}
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -41,8 +41,11 @@ defmodule OpenTelemetry.MixProject do
   end
 
   def erlang_docs() do
-    [{"README.md", [title: "Overview"]} |
-    (for file <- Path.wildcard("edoc/*.md"), file != "edoc/README.md", do:
-      {file, [title: Path.basename(file, ".md")]})]
+    files =
+      for file <- Path.wildcard("edoc/*.md"),
+        file != "edoc/README.md",
+        do: {file, [title: Path.basename(file, ".md")]}
+
+    [{"README.md", [title: "Overview"]} | files]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -14,9 +14,10 @@ defmodule OpenTelemetry.MixProject do
       # source_url: "https://github.com/USER/PROJECT",
       # homepage_url: "http://YOUR_PROJECT_HOMEPAGE",
       docs: [
-        main: "OpenTelemetry"
+        markdown_processor: ExDoc.Markdown.Cmark,
+        main: "OpenTelemetry",
         # logo: "path/to/logo.png",
-        # extras: ["README.md"]
+        extras: erlang_docs()
       ]
     ]
   end
@@ -34,7 +35,14 @@ defmodule OpenTelemetry.MixProject do
 
   def deps() do
     [
+      {:cmark, "~> 0.7", only: :dev, runtime: false},
       {:ex_doc, "~> 0.21", only: :dev, runtime: false}
     ]
+  end
+
+  def erlang_docs() do
+    [{"README.md", [title: "Overview"]} |
+    (for file <- Path.wildcard("edoc/*.md"), file != "edoc/README.md", do:
+      {file, [title: Path.basename(file, ".md")]})]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
 %{
+  "cmark": {:hex, :cmark, "0.7.0", "cf20106714b35801df3a2250a8ca478366f93ad6067df9d6815c80b2606ae01e", [:make, :mix], [], "hexpm", "deffa0b66cba126433efb54c068354bcf7c1fd8ba0f579741ab1d3cb26e0f942"},
   "earmark": {:hex, :earmark, "1.4.2", "3aa0bd23bc4c61cf2f1e5d752d1bb470560a6f8539974f767a38923bb20e1d7f", [:mix], [], "hexpm", "5e8806285d8a3a8999bd38e4a73c58d28534c856bc38c44818e5ba85bbda16fb"},
   "ex_doc": {:hex, :ex_doc, "0.21.2", "caca5bc28ed7b3bdc0b662f8afe2bee1eedb5c3cf7b322feeeb7c6ebbde089d6", [:mix], [{:earmark, "~> 1.3.3 or ~> 1.4", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm", "f1155337ae17ff7a1255217b4c1ceefcd1860b7ceb1a1874031e7a861b052e39"},
   "makeup": {:hex, :makeup, "1.0.0", "671df94cf5a594b739ce03b0d0316aa64312cee2574b6a44becb83cd90fb05dc", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "a10c6eb62cca416019663129699769f0c2ccf39428b3bb3c0cb38c718a0c186d"},

--- a/rebar.config
+++ b/rebar.config
@@ -3,11 +3,11 @@
 
 {profiles,
  [{docs, [{deps, [edown]},
-           {edoc_opts,
-            [{doclet, edown_doclet},
-             {preprocess, true},
-             {dir, "edoc"},
-             {subpackages, true}]}]},
+          {edoc_opts,
+           [{doclet, edown_doclet},
+            {preprocess, true},
+            {dir, "edoc"},
+            {subpackages, true}]}]},
   {test, [{erl_opts, [nowarn_export_all]},
           {deps, [wts]},
           {ct_opts, [{ct_hooks, [cth_surefire]}]}]}]}.

--- a/rebar.config
+++ b/rebar.config
@@ -2,7 +2,13 @@
 {deps, []}.
 
 {profiles,
- [{test, [{erl_opts, [nowarn_export_all]},
+ [{docs, [{deps, [edown]},
+           {edoc_opts,
+            [{doclet, edown_doclet},
+             {preprocess, true},
+             {dir, "edoc"},
+             {subpackages, true}]}]},
+  {test, [{erl_opts, [nowarn_export_all]},
           {deps, [wts]},
           {ct_opts, [{ct_hooks, [cth_surefire]}]}]}]}.
 

--- a/src/opentelemetry_api.app.src
+++ b/src/opentelemetry_api.app.src
@@ -7,8 +7,5 @@
     stdlib
    ]},
   {env,[]},
-  {modules, []},
-
-  {licenses, ["Apache 2.0"]},
-  {links, []}
+  {modules, []}
  ]}.


### PR DESCRIPTION
Docs still need to be actually written but this PR sets up the hexdocs for including erlang and elixir docs in the same page.