### PR TITLE
Cleanup Elixir code

### DIFF
--- a/lib/open_telemetry/tracer.ex
+++ b/lib/open_telemetry/tracer.ex
@@ -33,9 +33,9 @@ defmodule OpenTelemetry.Tracer do
   `parent` option given then the Tracer checks for an extracted SpanContext to use as the parent. If
   there is also no extracted context then the created Span is a root Span.
   """
-  defmacro start_span(name, start_opts \\ quote(do: %{})) do
-    quote do
-      :ot_tracer.start_span(:opentelemetry.get_tracer(__MODULE__), unquote(name), unquote(start_opts))
+  defmacro start_span(name, opts \\ quote(do: %{})) do
+    quote bind_quoted: [name: name, start_opts: opts] do
+      :ot_tracer.start_span(:opentelemetry.get_tracer(__MODULE__), name, start_opts)
     end
   end
 
@@ -43,8 +43,8 @@ defmodule OpenTelemetry.Tracer do
   Takes a `t:OpenTelemetry.span_ctx/0` and the Tracer sets it to the currently active Span.
   """
   defmacro set_span(span_ctx) do
-    quote do
-      :ot_tracer.set_span(:opentelemetry.get_tracer(__MODULE__), unquote(span_ctx))
+    quote bind_quoted: [span_ctx: span_ctx] do
+      :ot_tracer.set_span(:opentelemetry.get_tracer(__MODULE__), span_ctx)
     end
   end
 
@@ -72,6 +72,15 @@ defmodule OpenTelemetry.Tracer do
             unquote(name),
             unquote(start_opts),
             fn _ -> unquote(block) end)
+    end
+  end
+
+  @doc """
+  Returns the currently active `t:OpenTelemetry.tracer_ctx/0`.
+  """
+  defmacro current_ctx() do
+    quote do
+      :ot_tracer.current_ctx(:opentelemetry.get_tracer(__MODULE__))
     end
   end
 

--- a/test/open_telemetry_test.exs
+++ b/test/open_telemetry_test.exs
@@ -1,29 +1,26 @@
 defmodule OpenTelemetryTest do
   use ExUnit.Case, async: true
 
-  require OpenTelemetry.Tracer
-  require OpenTelemetry.Span
+  require OpenTelemetry.Tracer, as: Tracer
+  require OpenTelemetry.Span, as: Span
 
   test "current_span tracks nesting" do
-    _ctx1 = OpenTelemetry.Tracer.start_span("span-1")
-    ctx2 = OpenTelemetry.Tracer.start_span("span-2")
+    _ctx1 = Tracer.start_span("span-1")
+    ctx2 = Tracer.start_span("span-2")
 
-    assert ctx2 == OpenTelemetry.Tracer.current_span_ctx()
+    assert ctx2 == Tracer.current_span_ctx()
   end
 
   test "closing a span makes the parent current" do
-    ctx1 = OpenTelemetry.Tracer.start_span("span-1")
-    ctx2 = OpenTelemetry.Tracer.start_span("span-2")
+    ctx1 = Tracer.start_span("span-1")
+    ctx2 = Tracer.start_span("span-2")
 
-    assert ctx2 == OpenTelemetry.Tracer.current_span_ctx()
+    assert ctx2 == Tracer.current_span_ctx()
     OpenTelemetry.Tracer.end_span()
-    assert ctx1 == OpenTelemetry.Tracer.current_span_ctx()
+    assert ctx1 == Tracer.current_span_ctx()
   end
 
   test "macro start_span" do
-    alias OpenTelemetry.Tracer, as: Tracer
-    alias OpenTelemetry.Span, as: Span
-
     Tracer.with_span "span-1" do
       Tracer.with_span "span-2" do
         Span.set_attribute("attr-1", "value-1")
@@ -35,5 +32,4 @@ defmodule OpenTelemetryTest do
       end
     end
   end
-
 end


### PR DESCRIPTION
- Macros use `:bind_quoted` where possible
- Remove needless aliases in tests