### PR TITLE
Add callbacks for getting the Resource from a tracer provider

### DIFF
--- a/src/ot_tracer_provider.erl
+++ b/src/ot_tracer_provider.erl
@@ -33,6 +33,7 @@
 
 -callback init(term()) -> {ok, cb_state()}.
 -callback register_tracer(atom(), string(), cb_state()) -> boolean().
+-callback resource(cb_state()) -> term() | undefined.
 
 -record(state, {callback :: module(),
                 cb_state :: term()}).
@@ -40,13 +41,13 @@
 start_link(ProviderModule, Opts) ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [ProviderModule, Opts], []).
 
--spec resource() -> ot_resource:t().
+-spec resource() -> term() | undefined.
 resource() ->
     try
         gen_server:call(?MODULE, resource)
     catch exit:{noproc, _} ->
             %% ignore because no SDK has been included and started
-            ot_resource:create([])
+            undefined
     end.
 
 

--- a/src/ot_tracer_provider.erl
+++ b/src/ot_tracer_provider.erl
@@ -25,7 +25,8 @@
 
 -export([init/1,
          handle_call/3,
-         handle_cast/2]).
+         handle_cast/2,
+         code_change/3]).
 
 -type cb_state() :: term().
 
@@ -80,5 +81,11 @@ handle_call(_Msg, _From, State) ->
 
 handle_cast(_Msg, State) ->
     {noreply, State}.
+
+%% TODO: Use `Extra' as options to update the state like the sampler?
+code_change(_OldVsn, State=#state{callback=Cb,
+                                  cb_state=CbState}, _Extra) ->
+    NewCbState = Cb:code_change(CbState),
+    {ok, State#state{cb_state=NewCbState}}.
 
 %%


### PR DESCRIPTION
This change has made me think we'll want to move the genserver to the SDK and only have the callbacks in the API. But for now this provides a way for the Resource to be fetched so it can be used at span export time.