### PR TITLE
Add accessors to deconstruct Span

### DIFF
--- a/lib/open_telemetry.ex
+++ b/lib/open_telemetry.ex
@@ -133,7 +133,7 @@ defmodule OpenTelemetry do
   defdelegate link(trace_id, span_id, attributes, tracestate), to: :opentelemetry
 
   @doc """
-  Creates a list of `t:link/0` from a list of 3-tuples.
+  Creates a list of `t:link/0` from a list of 4-tuples.
   """
   @spec links([{integer(), integer(), list(), list()}]) :: [link()]
   defdelegate links(link_list), to: :opentelemetry

--- a/lib/open_telemetry/span.ex
+++ b/lib/open_telemetry/span.ex
@@ -27,6 +27,25 @@ defmodule OpenTelemetry.Span do
   """
 
   @doc """
+  Get the SpanId of a Span.
+  """
+  @spec span_id(OpenTelemetry.span()) :: OpenTelemetry.span_id()
+  defdelegate span_id(span), to: :ot_span
+
+  @doc """
+  Get the TraceId of a Span.
+  """
+  @spec trace_id(OpenTelemetry.span()) :: OpenTelemetry.trace_id()
+  defdelegate trace_id(span), to: :ot_span
+
+  @doc """
+  Get the Tracestate of a Span.
+  """
+  @spec tracestate(OpenTelemetry.span()) :: OpenTelemetry.tracestate()
+  defdelegate tracestate(span), to: :ot_span
+
+
+  @doc """
   Set an attribute with key and value on the currently active Span.
   """
   @spec set_attribute(OpenTelemetry.attribute_key(), OpenTelemetry.attribute_value()) :: boolean()

--- a/lib/open_telemetry/span.ex
+++ b/lib/open_telemetry/span.ex
@@ -29,19 +29,19 @@ defmodule OpenTelemetry.Span do
   @doc """
   Get the SpanId of a Span.
   """
-  @spec span_id(OpenTelemetry.span()) :: OpenTelemetry.span_id()
+  @spec span_id(OpenTelemetry.span_ctx()) :: OpenTelemetry.span_id()
   defdelegate span_id(span), to: :ot_span
 
   @doc """
   Get the TraceId of a Span.
   """
-  @spec trace_id(OpenTelemetry.span()) :: OpenTelemetry.trace_id()
+  @spec trace_id(OpenTelemetry.span_ctx()) :: OpenTelemetry.trace_id()
   defdelegate trace_id(span), to: :ot_span
 
   @doc """
   Get the Tracestate of a Span.
   """
-  @spec tracestate(OpenTelemetry.span()) :: OpenTelemetry.tracestate()
+  @spec tracestate(OpenTelemetry.span_ctx()) :: OpenTelemetry.tracestate()
   defdelegate tracestate(span), to: :ot_span
 
 

--- a/src/ot_span.erl
+++ b/src/ot_span.erl
@@ -19,6 +19,9 @@
 -module(ot_span).
 
 -export([get_ctx/2,
+         trace_id/1,
+         span_id/1,
+         tracestate/1,
          is_recording/2,
          set_attribute/4,
          set_attributes/3,
@@ -125,6 +128,16 @@ update_name(Tracer, SpanCtx, SpanName) when ?is_recording(SpanCtx) ->
     ?DO(Tracer, SpanCtx, [SpanName]);
 update_name(_, _, _) ->
     false.
+
+%% accessors
+-spec trace_id(opentelemetry:span()) -> opentelemetry:trace_id().
+trace_id(#span_ctx{ trace_id = TraceId }) -> TraceId.
+
+-spec span_id(opentelemetry:span()) -> opentelemetry:span_id().
+span_id(#span_ctx{ span_id = SpanId }) -> SpanId.
+
+-spec tracestate(opentelemetry:span()) -> opentelemetry:tracestate().
+tracestate(#span_ctx{ tracestate = Tracestate }) -> Tracestate.
 
 %% internal functions
 

--- a/src/ot_span.erl
+++ b/src/ot_span.erl
@@ -130,13 +130,13 @@ update_name(_, _, _) ->
     false.
 
 %% accessors
--spec trace_id(opentelemetry:span()) -> opentelemetry:trace_id().
+-spec trace_id(opentelemetry:span_ctx()) -> opentelemetry:trace_id().
 trace_id(#span_ctx{ trace_id = TraceId }) -> TraceId.
 
--spec span_id(opentelemetry:span()) -> opentelemetry:span_id().
+-spec span_id(opentelemetry:span_ctx()) -> opentelemetry:span_id().
 span_id(#span_ctx{ span_id = SpanId }) -> SpanId.
 
--spec tracestate(opentelemetry:span()) -> opentelemetry:tracestate().
+-spec tracestate(opentelemetry:span_ctx()) -> opentelemetry:tracestate().
 tracestate(#span_ctx{ tracestate = Tracestate }) -> Tracestate.
 
 %% internal functions

--- a/test/open_telemetry_test.exs
+++ b/test/open_telemetry_test.exs
@@ -32,4 +32,24 @@ defmodule OpenTelemetryTest do
       end
     end
   end
+
+  test "can deconstruct a span context" do
+    Tracer.with_span "span-1" do
+      span = Tracer.current_span_ctx()
+
+      assert nil != Span.trace_id(span)
+      assert nil != Span.span_id(span)
+      assert []   = Span.tracestate(span)
+    end
+  end
+
+  test "can establish link to parent trace" do
+    parent_trace_id = 1
+    expected_link = OpenTelemetry.link(parent_trace_id, 2, [], [])
+    Tracer.with_span "span-1", %{ links: [expected_link] } do
+      span = Tracer.current_span_ctx()
+
+      assert parent_trace_id == Span.trace_id(span)
+    end
+  end
 end

--- a/test/open_telemetry_test.exs
+++ b/test/open_telemetry_test.exs
@@ -42,14 +42,4 @@ defmodule OpenTelemetryTest do
       assert []   = Span.tracestate(span)
     end
   end
-
-  test "can establish link to parent trace" do
-    parent_trace_id = 1
-    expected_link = OpenTelemetry.link(parent_trace_id, 2, [], [])
-    Tracer.with_span "span-1", %{ links: [expected_link] } do
-      span = Tracer.current_span_ctx()
-
-      assert parent_trace_id == Span.trace_id(span)
-    end
-  end
 end

--- a/test/opentelemetry_api_SUITE.erl
+++ b/test/opentelemetry_api_SUITE.erl
@@ -9,7 +9,7 @@
 -include("tracer.hrl").
 
 all() ->
-    [noop_tracer, update_span_data, noop_with_span, macros].
+    [noop_tracer, update_span_data, noop_with_span, macros, can_create_link_from_span].
 
 init_per_suite(Config) ->
     application:load(opentelemetry_api),
@@ -17,6 +17,26 @@ init_per_suite(Config) ->
 
 end_per_suite(_Config) ->
     ok.
+
+can_create_link_from_span(_Config) ->
+  %% start a span to create a link to
+  SpanCtx = ?start_span(<<"span-1">>),
+
+  %% extract individual values from span context
+  TraceId = ot_span:trace_id(SpanCtx),
+  SpanId = ot_span:span_id(SpanCtx),
+  Tracestate = ot_span:tracestate(SpanCtx),
+
+  %% end span, so there's no current span set
+  ?end_span(),
+
+  %% we don't need any attributes for this test
+  Attributes = [],
+
+  %% attempt to create a link
+  Link = opentelemetry:link(TraceId, SpanId, Attributes, Tracestate),
+  ?assertMatch(Link, #link{}).
+
 
 noop_tracer(_Config) ->
     %% start a span and 2 children

--- a/test/opentelemetry_api_SUITE.erl
+++ b/test/opentelemetry_api_SUITE.erl
@@ -35,7 +35,11 @@ can_create_link_from_span(_Config) ->
 
   %% attempt to create a link
   Link = opentelemetry:link(TraceId, SpanId, Attributes, Tracestate),
-  ?assertMatch(Link, #link{}).
+  ?assertMatch(#link{ trace_id = TraceId
+                    , span_id = SpanId
+                    , attributes = Attributes
+                    , tracestate = Tracestate
+                    }, Link).
 
 
 noop_tracer(_Config) ->


### PR DESCRIPTION
When trying to link traces across separate systems (either linked via
HTTP calls or a message queue), having direct access to the TraceID and the
SpanID make it easier to serialize this properly and recreate a Link on
the receiving end.

This PR adds support for deconstructing a Span Context to get access to
these values.

I've added a couple of tests but they aren't all passing, so could use a
hand getting the test for establishing links to parent trace in shape.