### PR TITLE
Update span add_event docs variable name

### DIFF
--- a/lib/open_telemetry/span.ex
+++ b/lib/open_telemetry/span.ex
@@ -7,7 +7,7 @@ defmodule OpenTelemetry.Span do
       ...
       event = "ecto.query"
       ecto_attributes = OpenTelemetry.event([{"query", query}, {"total_time", total_time}])
-      OpenTelemetry.Span.add_event(event, ecto_event)
+      OpenTelemetry.Span.add_event(event, ecto_attributes)
       ...
 
   A Span represents a single operation within a trace. Spans can be nested to form a trace tree.


### PR DESCRIPTION
Seems like the variables on lines 9,10 (`ecto_attributes`, and `ecto_event`) are the same variable, but one or the other is misnamed.