### PR TITLE
Unspecified is not a valid span kind

### DIFF
--- a/include/opentelemetry.hrl
+++ b/include/opentelemetry.hrl
@@ -24,7 +24,6 @@
 %% for use in guards: sampling bit is the first bit in 8-bit trace options
 -define(IS_SPAN_ENABLED(TraceOptions), (TraceOptions band 1) =/= 0).
 
--define(SPAN_KIND_UNSPECIFIED, 'SPAN_KIND_UNSPECIFIED').
 -define(SPAN_KIND_INTERNAL, 'INTERNAL').
 -define(SPAN_KIND_SERVER, 'SERVER').
 -define(SPAN_KIND_CLIENT, 'CLIENT').

--- a/src/opentelemetry.erl
+++ b/src/opentelemetry.erl
@@ -100,8 +100,7 @@
 -type attribute()          :: {unicode:unicode_binary(), attribute_value()}.
 -type attributes()         :: [attribute()].
 
--type span_kind()          :: ?SPAN_KIND_UNSPECIFIED |
-                              ?SPAN_KIND_INTERNAL    |
+-type span_kind()          :: ?SPAN_KIND_INTERNAL    |
                               ?SPAN_KIND_SERVER      |
                               ?SPAN_KIND_CLIENT      |
                               ?SPAN_KIND_PRODUCER    |


### PR DESCRIPTION
`unspecified` is not a valid span kind https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#spankind.