### PR TITLE
Add atom support

### DIFF
--- a/include/opentelemetry.hrl
+++ b/include/opentelemetry.hrl
@@ -61,7 +61,7 @@
 
 -record(event, {
           system_time_nano :: non_neg_integer(),
-          name             :: unicode:unicode_binary(),
+          name             :: unicode:unicode_binary() | atom(),
           attributes = []  :: opentelemetry:attributes()
          }).
 

--- a/src/opentelemetry.erl
+++ b/src/opentelemetry.erl
@@ -93,11 +93,11 @@
 
 -type span_ctx()           :: #span_ctx{}.
 -type span()               :: term().
--type span_name()          :: unicode:unicode_binary().
+-type span_name()          :: unicode:unicode_binary() | atom().
 
--type attribute_key()      :: unicode:unicode_binary().
+-type attribute_key()      :: unicode:unicode_binary() | atom().
 -type attribute_value()    :: any().
--type attribute()          :: {unicode:unicode_binary(), attribute_value()}.
+-type attribute()          :: {attribute_key(), attribute_value()}.
 -type attributes()         :: [attribute()].
 
 -type span_kind()          :: ?SPAN_KIND_INTERNAL    |


### PR DESCRIPTION
Allow span name, event name, and attribute keys to be atoms as a memory performance optimization. Exporters can then encode to a unicode binary on the way out.